### PR TITLE
Linux Flatpak "Workaround" (Kinda) lol.

### DIFF
--- a/src/content/.obsidian/misc/linux-flatpak-sandbox-notice.txt
+++ b/src/content/.obsidian/misc/linux-flatpak-sandbox-notice.txt
@@ -1,0 +1,6 @@
+CAN'T ACCESS TERMINAL
+DUE TO FLATPAK SANDBOX
+-----------------------------------------------
+Right Click In Opened File-Manager
+And You Should See Something Like 
+"Open In Terminal" Option.

--- a/src/content/.obsidian/misc/linux-flatpak-sandbox-notice.txt
+++ b/src/content/.obsidian/misc/linux-flatpak-sandbox-notice.txt
@@ -1,6 +1,9 @@
-CAN'T ACCESS TERMINAL
-DUE TO FLATPAK SANDBOX
------------------------------------------------
+CAN'T ACCESS TERMINAL CONSISTENTLY
+ON LINUX DUE TO FLATPAK SANDBOX !
+---------------------------------
+
+Partial Workaround:
+
 Right Click In Opened File-Manager
 And You Should See Something Like 
 "Open In Terminal" Option.

--- a/src/content/.obsidian/plugins/obsidian-shellcommands/data.json
+++ b/src/content/.obsidian/plugins/obsidian-shellcommands/data.json
@@ -28,7 +28,7 @@
       "platform_specific_commands": {
         "default": "wt -d \"{{vault_path}}/../..\"",
         "darwin": "osascript -e 'tell application \"Terminal\" to do script \"cd \\\"{{vault_path}}/../..\\\" && bash\"'",
-        "linux": "x-terminal-emulator -e \"bash -c 'cd \\\"{{vault_path}}/../..\\\"; exec bash'\""
+        "linux": "xdg-open ../../ && cat .obsidian/misc/linux-flatpak-sandbox-notice.txt"
       },
       "shells": {},
       "alias": "Start Terminal",
@@ -40,7 +40,7 @@
       },
       "output_handlers": {
         "stdout": {
-          "handler": "ignore",
+          "handler": "notification",
           "convert_ansi_code": true
         },
         "stderr": {


### PR DESCRIPTION
The old Linux command to `Start Terminal` was broken; Sadly, I'm not aware of a global way to launch a terminal via Linux atm ... well without a super convoluted shell-script & the Flathub distribution of Obsidian is sandboxed enough that, doesn't even have access to any of the Terminal apps anyways without flatpak-spawner that would require overrides (if that would even work, I got frustrated and gave up lol)

This PR adds a 'partial workaround'. Instead of actually launching a terminal, it uses xdg-open which should be available near-if-not universally on Linux Distros, but certainly it ships as part of the sandbox env in the flatpak -- to launch the default file-manager in the top-level path of the repo; While prompting the user they can probably just right click and 'open in terminal'. This adds a right-click and select (/click) to the process but is far more consistent across envs.

In-practice, we have a new file that displays via cat in the notification-bubble for stdout we enabled. 
That file is `.obsidian/misc/linux-flatpak-sandbox-notice.txt`:

```
CAN'T ACCESS TERMINAL CONSISTENTLY
ON LINUX DUE TO FLATPAK SANDBOX !
---------------------------------
Partial Workaround:

Right Click In Opened File-Manager
And You Should See Something Like 
"Open In Terminal" Option.

```

The new command for Linux is now:
```
xdg-open ../../ && cat .obsidian/misc/linux-flatpak-sandbox-notice.txt
```

This is the best solution I can think of long-term. The flatpak sandbox is always going to be an issue for default behavior. Long-term it might be worth looking at permissions for the sandbox more via overrides, as said I tried and got frustrated and it looks like the creator of the extension did too via linked page when it detects flatpak in settings for shellcommands. Think if something that can be found to work, notably to get `flatpak-spawn --host whatever` writing a script to cover way more bases and/or be "universal enough" for launching terms becomes more viable. Also too, if something like https://gitlab.freedesktop.org/Vladimir-csp/xdg-terminal-exec actually gets implemented / adopted. lol