### PR TITLE
Added Obsidian Image Size

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import { remarkObsidianEmbeds } from './src/utils/remark-obsidian-embeds.ts';
 import remarkBases from './src/utils/remark-bases.ts';
 import remarkInlineTags from './src/utils/remark-inline-tags.ts';
 import { remarkObsidianComments } from './src/utils/remark-obsidian-comments.ts';
+import remarkObsidianImageSize from './src/utils/remark-obsidian-image-size.ts';
 import remarkMath from 'remark-math';
 import remarkReadingTime from 'remark-reading-time';
 import remarkToc from 'remark-toc';
@@ -117,7 +118,7 @@ image: {
       containers: ['#swup-container'],
       smoothScrolling: false,
       cache: true,
-      preload: true, 
+      preload: true,
       accessibility: false,
       updateHead: true,
       updateBodyClass: false,
@@ -134,6 +135,7 @@ image: {
   ],
   markdown: {
       remarkPlugins: [
+      remarkObsidianImageSize, // Parse Obsidian image size syntax first
       remarkInternalLinks,
       remarkInlineTags,
       remarkObsidianComments, // Remove Obsidian comments (%%...%%) early in processing
@@ -148,7 +150,7 @@ image: {
       remarkImageGrids,
       remarkMermaid,
       [remarkReadingTime, {}],
-      [remarkToc, { 
+      [remarkToc, {
         tight: true,
         ordered: false,
         maxDepth: 3,

--- a/public/graph/graph-data.json
+++ b/public/graph/graph-data.json
@@ -15,6 +15,13 @@
       "connections": 6
     },
     {
+      "id": "image-sizing-test",
+      "type": "post",
+      "title": "Image Sizing Test",
+      "slug": "image-sizing-test",
+      "connections": 0
+    },
+    {
       "id": "obsidian-embeds-demo",
       "type": "post",
       "title": "Obsidian Embeds Demo",
@@ -119,9 +126,9 @@
     }
   ],
   "metadata": {
-    "totalPosts": 5,
+    "totalPosts": 6,
     "totalConnections": 16,
     "maxNodesApplied": false,
-    "originalNodeCount": 5
+    "originalNodeCount": 6
   }
 }

--- a/src/components/ImageGalleryManager.astro
+++ b/src/components/ImageGalleryManager.astro
@@ -13,14 +13,14 @@ import { siteConfig } from '../config';
       lightboxInstance: any;
     }
   }
-  
+
   function initializeImageGalleries() {
     const contentElement = document.querySelector('.prose');
     if (!contentElement) {
       return;
     }
     const paragraphs = contentElement.querySelectorAll('p');
-    
+
     // Find all paragraphs with images (single or multiple)
     const imageParagraphs: { paragraph: Element; index: number; imageCount: number }[] = [];
     paragraphs.forEach((para, index) => {
@@ -31,17 +31,17 @@ import { siteConfig } from '../config';
         imageParagraphs.push({ paragraph: para, index: index, imageCount: nonLinkedImages.length });
       }
     });
-    
+
     // Process each image paragraph
     imageParagraphs.forEach((paraInfo) => {
       const { paragraph, imageCount } = paraInfo;
-      
+
       // Process paragraphs with 1 or more images
       if (imageCount >= 1) {
-        
+
         // Create gallery container
         const galleryContainer = document.createElement('div');
-        
+
         if (imageCount === 1) {
           galleryContainer.className = 'image-grid image-grid-1 my-2';
         } else if (imageCount === 2) {
@@ -51,11 +51,17 @@ import { siteConfig } from '../config';
         } else if (imageCount >= 4) {
           galleryContainer.className = 'image-grid image-grid-4 my-8';
         }
-        
+
         // Get all non-linked images from this paragraph
         const allImages = Array.from(paragraph.querySelectorAll('img'));
-        const images = allImages.filter(img => !img.closest('a'));
-        
+        // Filter out linked images AND manually-sized (Obsidian) images
+        const images = allImages.filter(img => !img.closest('a') && !img.classList.contains('obsidian-sized'));
+
+        // Skip processing if all images were manually sized
+        if (images.length === 0) {
+          return;
+        }
+
         // Check if there's any non-image content (like captions)
         // ONLY for single images - grids don't have captions
         let nonImageContent: Node[] = [];
@@ -70,7 +76,7 @@ import { siteConfig } from '../config';
             }
             return true;
           });
-          
+
           // If no caption content found in the same paragraph, check the next paragraph
           // BUT only if it looks like a caption (has italic text or links, and is not a heading)
           if (nonImageContent.length === 0) {
@@ -80,9 +86,9 @@ import { siteConfig } from '../config';
               const hasItalic = nextParagraph.querySelector('em, i');
               const hasLinks = nextParagraph.querySelector('a');
               const isHeading = nextParagraph.querySelector('h1, h2, h3, h4, h5, h6');
-              const hasOnlyText = nextParagraph.textContent && nextParagraph.textContent.trim() !== '' && 
+              const hasOnlyText = nextParagraph.textContent && nextParagraph.textContent.trim() !== '' &&
                                 nextParagraph.children.length <= 2; // Allow for simple formatting
-              
+
               // Only treat as caption if it has italic/links AND is not a heading
               if ((hasItalic || hasLinks || hasOnlyText) && !isHeading) {
                 // This looks like a caption, include it
@@ -93,17 +99,17 @@ import { siteConfig } from '../config';
             }
           }
         }
-        
+
         // Add each image to gallery
         images.forEach((img, imgIndex) => {
           const imageItem = document.createElement('div');
           imageItem.className = 'image-item';
-          
+
           const button = document.createElement('button');
           button.className = 'image-button w-full h-full group cursor-pointer';
           button.setAttribute('data-lightbox', 'gallery');
           button.setAttribute('aria-label', `View ${img.alt} in full size`);
-          
+
           // Add click event listener to open lightbox
           button.addEventListener('click', () => {
             // Dispatch custom event to open lightbox
@@ -111,15 +117,15 @@ import { siteConfig } from '../config';
               detail: { index: imgIndex, button: button }
             }));
           });
-          
+
           const imgClone = img.cloneNode(true) as HTMLImageElement;
           imgClone.className = 'w-full h-full object-cover rounded-lg transition-all duration-300 group-hover:shadow-lg group-hover:scale-[1.02]';
           imgClone.loading = 'lazy';
           imgClone.setAttribute('data-lightbox', 'gallery');
-          
+
           const overlay = document.createElement('div');
           overlay.className = 'absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300 rounded-lg flex items-center justify-center';
-          
+
           const zoomIcon = document.createElement('div');
           zoomIcon.className = 'w-6 h-6 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300';
           zoomIcon.innerHTML = `
@@ -127,19 +133,19 @@ import { siteConfig } from '../config';
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"></path>
             </svg>
           `;
-          
+
           overlay.appendChild(zoomIcon);
           button.appendChild(imgClone);
           button.appendChild(overlay);
           imageItem.appendChild(button);
           galleryContainer.appendChild(imageItem);
         });
-        
+
         // Create a container for the gallery and any non-image content
         const container = document.createElement('div');
         container.className = 'image-container';
         container.appendChild(galleryContainer);
-        
+
         // Add any non-image content (like captions) after the gallery
         if (nonImageContent.length > 0) {
           const captionContainer = document.createElement('div');
@@ -156,16 +162,16 @@ import { siteConfig } from '../config';
           });
           container.appendChild(captionContainer);
         }
-        
+
         // Replace the paragraph with the container
         paragraph.parentNode?.replaceChild(container, paragraph);
       }
     });
   }
-  
+
   // Initialize on page load
   document.addEventListener('DOMContentLoaded', initializeImageGalleries);
-  
+
   // Make function available globally for Swup
   window['initializeImageGalleries'] = initializeImageGalleries;
 </script>

--- a/src/content/posts/image-sizing-test.md
+++ b/src/content/posts/image-sizing-test.md
@@ -1,0 +1,57 @@
+---
+title: Image Sizing Test
+date: 2026-02-19
+description: ""
+tags: []
+image: ""
+imageAlt: ""
+imageOG: false
+hideCoverImage: false
+hideTOC: false
+targetKeyword: ""
+draft: false
+lastModified: 2026-02-19
+---
+# Image Sizing Test
+
+This page demonstrates how to use Obsidian-style image sizing syntax.
+
+## Obsidian Image Size Syntax
+
+### Width Only (pixels)
+![Test Image|300](attachments/spring-flowers.jpg)
+This will render the image at 300px wide, height auto.
+
+### Width x Height (pixels)
+![Test Image|200x150](attachments/spring-flowers.jpg)
+This will render the image at 200px wide and 150px tall.
+
+## Default Behavior
+
+Regular images without size syntax will be:
+- Centered automatically
+- Display at natural size up to 100% of container
+- No cropping or stretching
+
+![Regular Image](attachments/spring-flowers.jpg)
+This will render the image normally.
+
+## Examples
+
+```markdown
+<!-- Small thumbnail -->
+![Logo|80](/images/logo.png)
+
+<!-- Medium image -->
+![Screenshot|600](/images/screenshot.png)
+
+<!-- Fixed dimensions -->
+![Icon|48x48](/images/icon.png)
+```
+
+## Notes
+
+- Images with manual sizing will NOT be automatically added to image grids
+- Manually sized images use `object-fit: contain` to prevent cropping
+- Regular images remain centered by default
+- The lightbox/zoom feature still works for all images

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -199,7 +199,7 @@ p:has(.katex-display) {
   --code-text: 240 240 240;
   --inline-code-bg: 240 240 240;
   --inline-code-text: 33 33 33;
-  
+
   /* Highlight/selection colors */
   --selection-bg: 112 135 148;
 }
@@ -418,40 +418,40 @@ pre.astro-code code {
   border-radius: 0 !important;
 }
 
-/* Enhanced code block scrolling */  
-pre, .prose pre, .astro-code, .prose .astro-code {  
-  overflow-x: auto !important;  
-  scrollbar-width: thin !important;  
-  scrollbar-color: rgba(156, 163, 175, 0.5) transparent !important;  
-}  
-  
-/* Show scrollbars on hover for better UX */  
-pre:hover, .prose pre:hover,   
-.astro-code:hover, .prose .astro-code:hover {  
-  scrollbar-color: rgba(156, 163, 175, 0.8) transparent !important;  
-}  
-  
-/* Webkit scrollbar styling for code blocks */  
-pre::-webkit-scrollbar, .prose pre::-webkit-scrollbar,  
-.astro-code::-webkit-scrollbar, .prose .astro-code::-webkit-scrollbar {  
-  height: 8px !important;  
-  display: block !important;  
-}  
-  
-pre::-webkit-scrollbar-track, .prose pre::-webkit-scrollbar-track,  
-.astro-code::-webkit-scrollbar-track, .prose .astro-code::-webkit-scrollbar-track {  
-  background: transparent !important;  
-}  
-  
-pre::-webkit-scrollbar-thumb, .prose pre::-webkit-scrollbar-thumb,  
-.astro-code::-webkit-scrollbar-thumb, .prose .astro-code::-webkit-scrollbar-thumb {  
-  background-color: rgba(156, 163, 175, 0.5) !important;  
-  border-radius: 4px !important;  
-}  
-  
-pre::-webkit-scrollbar-thumb:hover, .prose pre::-webkit-scrollbar-thumb:hover,  
-.astro-code::-webkit-scrollbar-thumb:hover, .prose .astro-code::-webkit-scrollbar-thumb:hover {  
-  background-color: rgba(156, 163, 175, 0.8) !important;  
+/* Enhanced code block scrolling */
+pre, .prose pre, .astro-code, .prose .astro-code {
+  overflow-x: auto !important;
+  scrollbar-width: thin !important;
+  scrollbar-color: rgba(156, 163, 175, 0.5) transparent !important;
+}
+
+/* Show scrollbars on hover for better UX */
+pre:hover, .prose pre:hover,
+.astro-code:hover, .prose .astro-code:hover {
+  scrollbar-color: rgba(156, 163, 175, 0.8) transparent !important;
+}
+
+/* Webkit scrollbar styling for code blocks */
+pre::-webkit-scrollbar, .prose pre::-webkit-scrollbar,
+.astro-code::-webkit-scrollbar, .prose .astro-code::-webkit-scrollbar {
+  height: 8px !important;
+  display: block !important;
+}
+
+pre::-webkit-scrollbar-track, .prose pre::-webkit-scrollbar-track,
+.astro-code::-webkit-scrollbar-track, .prose .astro-code::-webkit-scrollbar-track {
+  background: transparent !important;
+}
+
+pre::-webkit-scrollbar-thumb, .prose pre::-webkit-scrollbar-thumb,
+.astro-code::-webkit-scrollbar-thumb, .prose .astro-code::-webkit-scrollbar-thumb {
+  background-color: rgba(156, 163, 175, 0.5) !important;
+  border-radius: 4px !important;
+}
+
+pre::-webkit-scrollbar-thumb:hover, .prose pre::-webkit-scrollbar-thumb:hover,
+.astro-code::-webkit-scrollbar-thumb:hover, .prose .astro-code::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(156, 163, 175, 0.8) !important;
 }
 
 /* Keyboard Shortcuts */
@@ -527,14 +527,14 @@ input[type="search"],
 textarea {
   @apply block w-full px-3 py-2 border border-primary-300 dark:border-primary-600 rounded-lg bg-white dark:bg-primary-800 text-primary-900 dark:text-primary-100 placeholder-primary-500 dark:placeholder-primary-400 focus:outline-none focus:ring-2 focus:ring-highlight-500 focus:border-transparent;
 }
-  
-.form-sleek {  
-  @apply space-y-4;  
-}  
-  
-.form-sleek input,  
-.form-sleek textarea {  
-  @apply bg-primary-50/50 dark:bg-primary-800/50 border-primary-200/50 dark:border-primary-600/50 backdrop-blur-sm;  
+
+.form-sleek {
+  @apply space-y-4;
+}
+
+.form-sleek input,
+.form-sleek textarea {
+  @apply bg-primary-50/50 dark:bg-primary-800/50 border-primary-200/50 dark:border-primary-600/50 backdrop-blur-sm;
 }
 
 /* Animations */
@@ -796,13 +796,13 @@ textarea {
   @apply text-highlight-600 dark:text-highlight-400 no-underline;
 }
 
-.prose a {  
-  @apply text-highlight-600 dark:text-highlight-400 font-medium no-underline transition-colors duration-200;  
-}  
-  
-.prose a:hover {  
-  @apply text-highlight-700 dark:text-highlight-300 no-underline;  
-} 
+.prose a {
+  @apply text-highlight-600 dark:text-highlight-400 font-medium no-underline transition-colors duration-200;
+}
+
+.prose a:hover {
+  @apply text-highlight-700 dark:text-highlight-300 no-underline;
+}
 
 
 .prose strong {
@@ -813,8 +813,70 @@ textarea {
   @apply border-l-4 border-primary-300 dark:border-primary-600 pl-6 py-2 bg-primary-50 dark:bg-primary-800/30 rounded-lg;
 }
 
+/* Default image styling - centered, no cropping */
 .prose img {
   @apply rounded-lg shadow-sm;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+/* Paragraphs containing only images should have reduced margins */
+.prose p:has(img:only-child) {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Obsidian-sized images - respect manual width/height, no forced aspect ratio */
+.prose img.obsidian-sized {
+  max-width: none; /* Allow images to exceed container if specified */
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  /* Ensure centering is maintained */
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Ensure manually-sized images in grids don't get forced into grid aspect ratio */
+.prose .image-grid img.obsidian-sized {
+  aspect-ratio: auto;
+  object-fit: contain;
+}
+
+/* Prevent gallery styles from affecting obsidian-sized images */
+.prose .image-item img.obsidian-sized,
+.prose .image-button img.obsidian-sized {
+  object-fit: contain !important;
+  aspect-ratio: auto !important;
+}
+
+/* Ensure obsidian-sized images that are NOT in galleries remain centered */
+.prose p img.obsidian-sized {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Paragraphs with only obsidian-sized images should have minimal margins */
+.prose p:has(img.obsidian-sized:only-child) {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+/* Hide <br> elements after obsidian-sized images to prevent unwanted gaps */
+/* This allows text to behave as a caption without a large break */
+.prose img.obsidian-sized + br {
+  display: none;
+}
+
+/* Ensure paragraphs with obsidian-sized image + text have proper spacing */
+.prose p:has(img.obsidian-sized) {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .prose mark {
@@ -1455,15 +1517,15 @@ svg:has(text:contains("mermaid version")) {
     min-height: 300px;
     max-height: 500px;
   }
-  
+
   .pdf-embed .pdf-info {
     @apply flex-col items-start gap-2;
   }
-  
+
   .pdf-embed .pdf-download-link {
     @apply w-full text-center;
   }
-  
+
   .audio-embed,
   .video-embed,
   .youtube-embed {

--- a/src/utils/remark-image-grids.ts
+++ b/src/utils/remark-image-grids.ts
@@ -4,6 +4,7 @@ import { visit } from "unist-util-visit";
 /**
  * Remark plugin to detect consecutive images in paragraphs and apply grid classes
  * This replaces the client-side JavaScript detection with build-time processing
+ * Skips paragraphs containing Obsidian-sized images (manually sized)
  */
 export function remarkImageGrids() {
   return (tree: Root) => {
@@ -38,8 +39,14 @@ export function remarkImageGrids() {
           }
         });
 
+        // Skip grid processing if any image has manual sizing (Obsidian syntax)
+        const hasObsidianSizedImage = images.some((img) => {
+          return img.data?.hProperties?.class?.includes('obsidian-sized');
+        });
+
         // Only process paragraphs with 2+ images and no other meaningful content
-        if (images.length >= 2 && otherNodes.length === 0) {
+        // Skip if any image has manual Obsidian sizing
+        if (images.length >= 2 && otherNodes.length === 0 && !hasObsidianSizedImage) {
           // Add image-grid classes to the paragraph
           if (!node.data) {
             node.data = {};

--- a/src/utils/remark-obsidian-image-size.ts
+++ b/src/utils/remark-obsidian-image-size.ts
@@ -1,0 +1,67 @@
+import type { Root, Image } from "mdast";
+import { visit } from "unist-util-visit";
+
+/**
+ * Remark plugin to parse Obsidian-style image size syntax
+ * Supports: ![alt|100x100](image.png) or ![alt|200](image.png)
+ * - ![alt|100x100] - width x height (pixels)
+ * - ![alt|200] - width only (pixels, height auto)
+ */
+export function remarkObsidianImageSize() {
+  return (tree: Root) => {
+    visit(tree, "image", (node: Image) => {
+      const alt = node.alt || "";
+
+      // Parse Obsidian syntax: alt|widthxheight or alt|width
+      const pipeIndex = alt.lastIndexOf('|');
+
+      if (pipeIndex !== -1) {
+        const actualAlt = alt.substring(0, pipeIndex).trim();
+        const sizePart = alt.substring(pipeIndex + 1).trim();
+
+        // Parse size: "100x100" or "200"
+        const sizeMatch = sizePart.match(/^(\d+(?:\.\d+)?)(?:x(\d+(?:\.\d+)?))?$/);
+
+        if (sizeMatch) {
+          const width = sizeMatch[1];
+          const height = sizeMatch[2] ? sizeMatch[2] : undefined;
+
+          // Update node properties
+          node.alt = actualAlt;
+
+          if (!node.data) {
+            node.data = {};
+          }
+          if (!node.data.hProperties) {
+            node.data.hProperties = {};
+          }
+
+          const hProperties = node.data.hProperties as Record<string, any>;
+
+          // Add inline style for width/height (in pixels)
+          const styleParts: string[] = [];
+
+          if (width) {
+            styleParts.push(`width: ${width}px`);
+          }
+
+          if (height) {
+            styleParts.push(`height: ${height}px`);
+          }
+
+          if (styleParts.length > 0) {
+            hProperties.style = styleParts.join('; ');
+          }
+
+          // Add class for targeting in CSS
+          hProperties.class = (hProperties.class || '').split(' ')
+            .filter(Boolean)
+            .concat('obsidian-sized')
+            .join(' ');
+        }
+      }
+    });
+  };
+}
+
+export default remarkObsidianImageSize;


### PR DESCRIPTION
## Problem
Sometimes you'd want to define the size of an image. You can do this in obsidian by writing an embed followed by its size, like `![alt|500](image.png)`. While this works in obsidian itself, it doesn't when building to astro modular. Images are cropped instead. While this is fine, the feature to decide whether you want the image to follow this behaviour or not is preferable.

## Solution
Design a new remark plugin that parses and supports how obsidian handles image size. These images are also centred by default and not cropped. These changes still respect the default image format and auto-grid processing. It's just that images that are formatted no longer follow these rules.

Check out the post titled `image-sizing-test.md` for a detailed look.

### Issue
Lightbox doesn't work for formatted images (I personally intended for it to be that way) and image caption doesn't work for these images. This I think is fine, because sometimes I don't want to add a caption, but next line is usually forced as a caption and I found that the only way to not have that is by creating a separator between the image and text (if that makes sense)

## Files Changes
- `astro.config.mjs`
- `ImageGalleryManager.astro`
- `global.css`
- `remark-image-grids.ts`
- `remark-obsidian-image-size.ts` (added file)